### PR TITLE
add build cache for docker images to speed up CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,15 +176,33 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}-
+            ${{ runner.os }}-buildx-
+
       - name: Test Docker Compose build (dev target)
         run: |
-          DOCKER_TARGET=dev docker compose build --no-cache
+          DOCKER_TARGET=dev docker compose build
+        env:
+          BUILDKIT_INLINE_CACHE: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          DOCKER_BUILDKIT: 1
 
       - name: Test Docker Compose build (prod target)
         run: |
-          DOCKER_TARGET=prod docker compose build --no-cache
+          DOCKER_TARGET=prod docker compose build
+        env:
+          BUILDKIT_INLINE_CACHE: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          DOCKER_BUILDKIT: 1
 
       - name: Clean up Docker images
+        if: always()
         run: docker system prune -af
 
   build:


### PR DESCRIPTION
This pull request updates the Docker build workflow to optimize build times and resource usage by introducing Docker layer caching and enabling BuildKit features. The most important changes are grouped below.

**Docker Build Performance Improvements:**

* Added a Docker layer caching step using the `actions/cache` action to cache layers in `/tmp/.buildx-cache`, which speeds up subsequent builds by reusing unchanged layers.
* Enabled BuildKit and inline cache features for both the dev and prod Docker Compose build steps by setting `BUILDKIT_INLINE_CACHE`, `COMPOSE_DOCKER_CLI_BUILD`, and `DOCKER_BUILDKIT` environment variables. This improves build efficiency and cache usage.

**Workflow Robustness:**

* Added a conditional to always run the Docker cleanup step, ensuring that Docker resources are properly cleaned up even if earlier steps fail.